### PR TITLE
ringbuffer: fix rb_get_bytes_used (modulo overflow)

### DIFF
--- a/ringbuffer.c
+++ b/ringbuffer.c
@@ -27,7 +27,10 @@ int rb_init(struct ringbuffer_t *rb)
 
 int rb_get_bytes_used(struct ringbuffer_t* rb)
 {
-  return((rb->tail - rb->head) % sizeof(rb->buf));
+  if (rb->tail >= rb->head)
+    return (rb->tail - rb->head);
+  else
+    return (rb->tail - rb->head) + sizeof(rb->buf);
 }
 
 int rb_read(struct ringbuffer_t *rb, uint8_t* buf, int count)
@@ -81,7 +84,7 @@ int rb_write(struct ringbuffer_t *rb, uint8_t* buf, int count)
 {
   int to_copy;
 
-  int bytes_used = (rb->tail - rb->head) % sizeof(rb->buf);
+  int bytes_used = rb_get_bytes_used(rb);
   //fprintf(stderr,"bytes_used = %d\n",bytes_used);
 
   if (bytes_used + count >= (int)sizeof(rb->buf)) {


### PR DESCRIPTION
Using the modulo to wrap around the buffer is unsafe because it's easy to have the values overflowing.

A simple "real" example from my debug:
Buffer size is 15Mb (15728640)
Pointer values:
tail=0x7f4b84c3b841 head=0x7f4b85b267e9

tail - head = -15642536
tail - head + buf_size = 86104 (correct)

(tail - head) % buf_size = 1134680 (wrong)

This "might" fix #3 

PS:
I just got a DVB-C modulator card (with 4 modulators) and I'm testing it with this tool and will try to enhance it.
But I see that this repo isn't updated for quite some time so I'm not sure if you're really interested in PR's...